### PR TITLE
MAID-2727: Signature::as_bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,13 @@ impl SharedSecretKey {
     }
 }
 
+impl Signature {
+    /// Return the signature as an array of bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.signature.0
+    }
+}
+
 impl SymmetricKey {
     /// Generates a new symmetric key.
     pub fn new() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ use maidsafe_utilities::serialisation::{deserialise, serialise, SerialisationErr
 use rand::Rng;
 use rust_sodium::crypto::{box_, sealedbox, secretbox, sign};
 use serde::{de::DeserializeOwned, Serialize};
+use std::fmt;
 use std::sync::Arc;
 
 /// Initialise random number generator for the key generation functions.
@@ -393,6 +394,18 @@ impl SymmetricKey {
 impl Default for SymmetricKey {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl fmt::Display for PublicId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for b in &self.sign[..] {
+            write!(f, "{:02x}", b)?;
+        }
+        for b in &self.encrypt[..] {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/mock_crypto.rs
+++ b/src/mock_crypto.rs
@@ -121,6 +121,7 @@ pub(crate) mod rust_sodium {
         pub(crate) mod box_ {
             use super::super::with_rng;
             use rand::Rng;
+            use std::ops::{Index, RangeFull};
 
             /// Number of bytes in a `PublicKey`.
             pub(crate) const PUBLICKEYBYTES: usize = 8;
@@ -133,6 +134,13 @@ pub(crate) mod rust_sodium {
             #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd,
                      Serialize)]
             pub(crate) struct PublicKey(pub(crate) [u8; PUBLICKEYBYTES]);
+
+            impl Index<RangeFull> for PublicKey {
+                type Output = [u8];
+                fn index(&self, index: RangeFull) -> &[u8] {
+                    self.0.index(index)
+                }
+            }
 
             /// Mock secret key for asymmetric encryption/decryption.
             #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Add a method to get the bytes of a `Signature`.