### PR TITLE
MAID-2727: Rename name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ struct CipherText {
 impl PublicId {
     /// Returns a public key representing this public identity.
     #[cfg(feature = "use-mock-crypto")]
-    pub fn name(&self) -> [u8; 32] {
+    pub fn signing_bytes(&self) -> [u8; 32] {
         // Pads the key to 32 bytes for mock-crypto
         let mut full_len_key = [0; 32];
         self.sign
@@ -138,7 +138,7 @@ impl PublicId {
 
     /// Returns a public key representing this public identity.
     #[cfg(not(feature = "use-mock-crypto"))]
-    pub fn name(&self) -> [u8; 32] {
+    pub fn signing_bytes(&self) -> [u8; 32] {
         self.sign.0
     }
 
@@ -600,11 +600,11 @@ mod tests {
 
     #[cfg(feature = "use-mock-crypto")]
     #[test]
-    fn name() {
+    fn signing_bytes() {
         let sk1 = SecretId::new();
         let pk1 = sk1.public_id();
         assert_eq!(
-            &pk1.name(),
+            &pk1.signing_bytes(),
             &[pk1.sign.0, pk1.sign.0, pk1.sign.0, pk1.sign.0].concat()[0..32]
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,13 @@ impl SharedSecretKey {
     }
 }
 
+impl Signature {
+    /// Return the signature as an array of bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.signature.0
+    }
+}
+
 impl SymmetricKey {
     /// Generates a new symmetric key.
     pub fn new() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ use maidsafe_utilities::serialisation::{deserialise, serialise, SerialisationErr
 use rand::Rng;
 use rust_sodium::crypto::{box_, sealedbox, secretbox, sign};
 use serde::{de::DeserializeOwned, Serialize};
+use std::fmt;
 use std::sync::Arc;
 
 /// Initialise random number generator for the key generation functions.
@@ -393,6 +394,18 @@ impl SymmetricKey {
 impl Default for SymmetricKey {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl fmt::Display for PublicId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for b in &self.sign[..] {
+            write!(f, "{:02x}", b)?;
+        }
+        for b in &self.encrypt[..] {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/mock_crypto.rs
+++ b/src/mock_crypto.rs
@@ -121,6 +121,7 @@ pub(crate) mod rust_sodium {
         pub(crate) mod box_ {
             use super::super::with_rng;
             use rand::Rng;
+            use std::ops::{Index, RangeFull};
 
             /// Number of bytes in a `PublicKey`.
             pub(crate) const PUBLICKEYBYTES: usize = 8;
@@ -133,6 +134,13 @@ pub(crate) mod rust_sodium {
             #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd,
                      Serialize)]
             pub(crate) struct PublicKey(pub(crate) [u8; PUBLICKEYBYTES]);
+
+            impl Index<RangeFull> for PublicKey {
+                type Output = [u8];
+                fn index(&self, index: RangeFull) -> &[u8] {
+                    self.0.index(index)
+                }
+            }
 
             /// Mock secret key for asymmetric encryption/decryption.
             #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
The name of `PublicId::name` is awkward for two reasons:

  * It conflicts with adding a `name` method to `PublicId` in routing which returns a `XorName`. In my current implementation of safe_crypto integration into routing I've named this method `xor_name` instead. Though this is inconsistent with all the other similar methods in routing which are just called `name`.

  * Using the signing bytes of a `PublicId` as it's name is a routing-ism which doesn't make a lot of sense in safe_crypto when viewed as a standalone library. Calling it `signing_bytes` makes it clear to a safe_crypto user what this method does, and it also makes it clear in the routing code what routing is using as a name.