### PR TITLE
Update lazy_static to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ version = "0.5.0"
 edition = "2018"
 
 [dependencies]
-lazy_static = { version = "~1.0.1", optional = true }
+lazy_static = { version = "~1.2.0", optional = true }
 maidsafe_utilities = "~0.16.0"
 quick-error = "~1.2.2"
 rand = "~0.4.2"
-rust_sodium = "~0.10.0"
+rust_sodium = "~0.10.2"
 scrypt = { version = "~0.1.2", default-features = false }
 serde = { version = "~1.0.66", features = ["rc"] }
 serde_derive = "~1.0.66"


### PR DESCRIPTION
We were falling behind on our lazy_static version.
Use lazy_static 1.2.0.
Use rust_sodium 0.10.2 which also has an updated lazy_static.