### PR TITLE
chore: add deprecation notice to README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR BSD-3-Clause"
 name = "safe_crypto"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_crypto"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 
 [dependencies]
@@ -15,7 +15,7 @@ maidsafe_utilities = "~0.18.0"
 quick-error = "~1.2.2"
 rand = "~0.4.2"
 rust_sodium = "~0.10.2"
-scrypt = { version = "~0.1.2", default-features = false }
+scrypt = { version = "0.2", default-features = false }
 serde = { version = "~1.0.101", features = ["rc"] }
 serde_derive = "~1.0.101"
 tiny-keccak = "~1.5.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # safe_crypto
 
+**⚠ DEPRECATED:** This repository (and crate) are deprecated and no longer used in active Safe Network projects.
+
 This is a convenience library providing abstractions for cryptographic functions required by other SAFE Network libraries.
 
 |Crate|Documentation|Linux/macOS|Windows|Issues|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 
 //! This is a convenience library providing abstractions for cryptographic functions required by
 //! other SAFE Network libraries.
+//!
+//! **⚠ DEPRECATED:** This repository (and crate) are deprecated and no longer used in active Safe Network projects.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
@@ -19,8 +21,7 @@
     exceeding_bitshifts,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     bad_style,


### PR DESCRIPTION
We no longer use this, and the repository is archived, but this isn't
reflected on crates.io (https://crates.io/crates/safe_crypto) or docs.rs
(https://docs.rs/safe_crypto).

To get things to build (which is necessary for the update to actually
make it crates.io/docs.rs), `scrypt` had to be upgraded (`0.1.x` has
been yanked). There's no publish CI for this, so that will have to be
done manually post-merge.

The version has been bumped to `0.8.1`.